### PR TITLE
Fix autodl column width

### DIFF
--- a/plugins.css
+++ b/plugins.css
@@ -439,6 +439,11 @@ hr {
   width: 200px;
   height: 270px;
 }
+
+#autodl-filters-list-buttons {
+  width: 200px;
+}
+
 #autodl-filters-tabs {
   margin-top: 5px;
 }


### PR DESCRIPTION
Recent updates to the AutoDL ruTorrent plugin leave the filters tab unusable. This change fixes that.